### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -757,7 +757,7 @@ _You can enable the following settings in Xcode by running [this script](resourc
 
   ```swift
   // WRONG
-  func age(of person, bornAt timeInterval) -> Int {
+  func age(of person: Person, bornAt: TimeInterval) -> Int {
     // ...
   }
 


### PR DESCRIPTION
#### Summary

Actual 
```swift
func age(of person, bornAt timeInterval) -> Int
```

Corrected method signature
```swift
func age(of person: Person, bornAt: TimeInterval) -> Int
```

#### Reasoning

Not valid Swift because parameters do not have a type.
